### PR TITLE
feat(parser): add support for fixed-length array types in schema generation

### DIFF
--- a/.changeset/silent-flowers-remain.md
+++ b/.changeset/silent-flowers-remain.md
@@ -1,0 +1,5 @@
+---
+"@zorsh/schema-gen": patch
+---
+
+Add support for fixed-length array types in schema generation

--- a/test/lib/parser.test.ts
+++ b/test/lib/parser.test.ts
@@ -37,6 +37,18 @@ describe("TypeParser", () => {
       input: "Vec<(u64, Location, String)>",
       expected: "b.vec(b.tuple([b.u64(), LocationSchema, b.string()]))",
     },
+    {
+      input: "[u8; 33]",
+      expected: "b.array(b.u8(), 33)",
+    },
+    {
+      input: "[String; 5]",
+      expected: "b.array(b.string(), 5)",
+    },
+    {
+      input: "[Vec<u8>; 10]",
+      expected: "b.array(b.vec(b.u8()), 10)",
+    },
   ]
 
   test.each(testCases)("parses and generates code for $input", ({ input, expected }) => {
@@ -50,5 +62,22 @@ describe("TypeParser", () => {
 
     const generated = parser.parse(input)
     expect(generated).toBe(expected)
+  })
+
+  test("handles complex array types", () => {
+    const complexCases = [
+      {
+        input: "HashMap<String, [u8; 32]>",
+        expected: "b.hashMap(b.string(), b.array(b.u8(), 32))",
+      },
+      {
+        input: "Vec<[u8; 64]>",
+        expected: "b.vec(b.array(b.u8(), 64))",
+      },
+    ]
+
+    for (const { input, expected } of complexCases) {
+      expect(parser.parse(input)).toBe(expected)
+    }
   })
 })


### PR DESCRIPTION
## Background

The schema generator currently fails to properly handle Rust fixed-length array types when generating Zorsh schemas. This affects both struct fields containing arrays and direct array type declarations.

For example, given this Rust type:
```rust
#[derive(BorshSchema)]
pub struct AccountPubkey {
    key: [u8; 33]
}
```

The generator currently produces invalid TypeScript:
```typescript
export const AccountPubkeySchema = b.struct({
  key: [u8; 33Schema
});
```

## Technical Details

The issue stems from how Borsh serializes array types in its schema format. When Borsh encounters a fixed-length array like `[u8; 33]`, it serializes the type name literally as the string `"[u8; 33]"` in the schema definition.

Our type parser was not recognizing this syntax pattern, causing it to treat the entire string as a type name rather than parsing it as an array declaration.

### Example of Borsh Schema Structure

When serializing a struct with an array field, Borsh generates a schema container that looks like:
```typescript
{
  declaration: 'AccountPubkey',
  definitions: Map(2) {
    'AccountPubkey' => {
      Struct: {
        fields: {
          NamedFields: [
            { name: 'key', declaration: '[u8; 33]' }
          ]
        }
      }
    },
    '[u8; 33]' => {
      Sequence: {
        lengthWidth: 0,
        lengthRange: { start: 33n, end: 33n },
        elements: 'u8'
      }
    }
  }
}
```

## Changes Made

1. Added array type detection and parsing to the TypeParser
2. Updated the main parse method to handle array types

## Note on Type Aliases

During investigation, I discovered that Borsh's schema generation for type aliases (e.g., `pub type AccountPubkeyAlias = [u8; 33]`) does not preserve the alias name in the schema. It only serializes the underlying type structure. This means we cannot currently generate properly named schemas for type aliases.

Example of schema for a type alias:
```typescript
{
  declaration: '[u8; 33]',
  definitions: Map(2) {
    '[u8; 33]' => {
      Sequence: {
        lengthWidth: 0,
        lengthRange: { start: 33n, end: 33n },
        elements: 'u8'
      }
    },
    'u8' => { Primitive: { size: 1 } }
  }
}
```

This limitation is inherent to how Borsh handles type aliases in its schema generation and would require upstream changes to preserve alias information.

## Testing

The changes have been tested with:
- Struct fields containing fixed-length arrays
- Various array element types
- Different array lengths
- Nested array types within other type constructs

Tests have been added to verify the parsing and generation of array types:
```typescript
test("handles array types correctly", () => {
  const testCases = [
    {
      input: "[u8; 33]",
      expected: "b.array(b.u8(), 33)",
    },
    // ... more test cases
  ]
})
```

Closes #8 